### PR TITLE
Snapshot tagger

### DIFF
--- a/files/snapshot_tagger.py
+++ b/files/snapshot_tagger.py
@@ -1,0 +1,29 @@
+import boto3,json,csv
+insta=boto3.client('ec2').describe_instances()
+instlist=[]
+ec2 = boto3.resource('ec2')
+
+for i in insta['Reservations']:
+		 instlist.append(i['Instances'][0])
+
+volumes=[]
+voltags=[]
+for m in instlist:
+    for l in m['BlockDeviceMappings']:
+            volumes.append({l['Ebs']['VolumeId']: m['Tags']})
+
+client = boto3.client('ec2')
+snap_vols={}
+snaps=client.describe_snapshots(OwnerIds=['188033381281'])['Snapshots']
+for i in snaps:
+    snap_vols.setdefault(i['VolumeId'],[]).append(i['SnapshotId'])
+
+for key,value in snap_vols.items():
+    for k2 in volumes:
+        if key in k2:
+            for z in value:
+                voltags.append({z: k2[key]})
+
+for tt in voltags:
+    for k,v in tt.items():
+        ec2.Snapshot(k).create_tags(Tags=v)

--- a/files/snapshot_tagger.py
+++ b/files/snapshot_tagger.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 import boto3,json,csv
 insta=boto3.client('ec2').describe_instances()
 instlist=[]

--- a/tasks/ec2_assets.yml
+++ b/tasks/ec2_assets.yml
@@ -14,6 +14,7 @@
   with_items:
   - pip
   - awscli
+  - boto3
 
 - name: Pip build dependencies are absent
   yum:
@@ -59,6 +60,7 @@
     - ec2_get_arn.sh
     - ec2_get_region.sh
     - ebs-snapshot.sh
+    - snapshot_tagger.py
   tags: assets
 
 - name: Add ebs-snapshot.cron to /etc/cron.daily

--- a/templates/ebs-snapshot.cron.j2
+++ b/templates/ebs-snapshot.cron.j2
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 /opt/oulib/aws/bin/ebs-snapshot.sh {{ ebs_snapshot_retention_days }}
+/opt/oulib/aws/bin/snapshot_tagger.py


### PR DESCRIPTION
Motivation and Context
-----
As snapshots are created in AWS they, by default and "normal" usage, do not inherit the volume's tags that they are snapshotted from. The script being added to the role, as well as cron.daily, will ensure that volume tags are being added to the snapshots as they are being created. This allows better searching and reporting capabilities on the volumes/snapshots

How Has This Been Tested?
-----
Local Python development utilizing boto3 python module
* Python 2.7
  - pip
  - boto3
  - AWS CLI 